### PR TITLE
feat: refine socket setup and document form UI

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,7 +17,7 @@ from app.utils.socket_util import GlobalNamespace, EmbeddingNamespace, ImageName
 db = SQLAlchemy()
 bcrypt = Bcrypt()
 mail = Mail()
-socketio = SocketIO(message_queue="amqp://", async_mode="eventlet", engineio_logger=True, logger=True, cors_allowed_origins=["newutil.rawcsav.com", "https://newutil.rawcsav.com", "http://localhost:8080"])
+socketio = SocketIO(message_queue="amqp://", async_mode="eventlet", cors_allowed_origins=["newutil.rawcsav.com", "https://newutil.rawcsav.com", "http://localhost:8080", "http://127.0.0.1:8080"])
 login_manager = LoginManager()
 
 
@@ -43,7 +43,7 @@ def create_app():
     CORS(app)
     db.init_app(app)
 
-    socketio.init_app(app, message_queue=app.config["CELERY_BROKER_URL"], async_mode="eventlet", engineio_logger=True, logger=True, cors_allowed_origins=["newutil.rawcsav.com", "https://newutil.rawcsav.com", "http://localhost:8080"])
+    socketio.init_app(app, message_queue=app.config["CELERY_BROKER_URL"], async_mode="eventlet", cors_allowed_origins=["newutil.rawcsav.com", "https://newutil.rawcsav.com", "http://localhost:8080", "http://127.0.0.1:8080"])
     socketio.on_namespace(ImageNamespace("/image"))
     socketio.on_namespace(EmbeddingNamespace("/embedding"))
     socketio.on_namespace(AudioNamespace("/audio"))

--- a/app/modules/cwd/cwd_util.py
+++ b/app/modules/cwd/cwd_util.py
@@ -121,7 +121,7 @@ def chat_completion_with_retry(messages, model, client, temperature, top_p):
     return client.chat.completions.create(model=model, messages=messages, temperature=temperature, top_p=top_p, stream=True)
 
 
-def ask(query, images, client, model: str = "gpt-4o"):
+def ask(query, images, client, model: str = "gpt-4-0125-preview"):
     modified_query, chunk_associations, doc_pages = append_knowledge_context(query, current_user.id, client)
     preferences = ChatPreferences.query.filter_by(user_id=current_user.id).first()
     temperature = preferences.temperature

--- a/app/modules/embedding/static/embedding.js
+++ b/app/modules/embedding/static/embedding.js
@@ -75,28 +75,28 @@ function createDocumentForms(fileList) {
     const file = fileList[i];
     const formHtml = `
   <div class="form-group">
-    <label>Document Title (optional):</label>
+    <label>Title&nbsp;(optional):</label>
     <input type="text" name="title" placeholder="Enter document title" value="${
       documentData[i]?.title || ""
     }" />
   </div>
   <div class="form-group">
-    <label>Author Name (optional):</label>
+    <label>Author&nbsp;(optional):</label>
     <input type="text" name="author" placeholder="Enter author's name" value="${
       documentData[i]?.author || ""
     }" />
   </div>
   <div class="form-group">
-    <label>Max Tokens per Chunk (default is 512):</label>
+    <label>Tokens per Chunk&nbsp;(default is 1024):</label>
     <input type="number" name="chunk_size" min="1" value="${
-      documentData[i]?.chunk_size || "512"
+      documentData[i]?.chunk_size || "1024"
     }" />
   </div>
   <div class="form-group">
     <label>
       <input type="checkbox" name="advanced_preprocessing" ${
         documentData[i]?.advanced_preprocessing ? "checked" : ""
-      } /> Enable Advanced Preprocessing
+      } />&nbsp;Advanced PDF Preprocessing?
     </label>
   </div>
 `;

--- a/app/modules/embedding/templates/embedding.html
+++ b/app/modules/embedding/templates/embedding.html
@@ -44,7 +44,7 @@
           >
           <p id="file-types-list">
             Accepted file types: <span class="file-type">.txt</span>,
-            <span class="file-type">.pdf</span>,
+            <span class="file-type">.pdf</span>
           </p>
 
           <input

--- a/app/static/dist/js/embedding.js
+++ b/app/static/dist/js/embedding.js
@@ -4,13 +4,13 @@ toast.textContent=message;toast.className=type;toast.style.display="block";toast
 function getCsrfToken(){return document.querySelector('meta[name="csrf-token"]').getAttribute("content");}
 function enableEditing(editButton){var listItem=editButton.closest("li");var form=listItem.querySelector("form.edit-document-form");var inputs=form.querySelectorAll(".editable");inputs.forEach(function(input){input.removeAttribute("readonly");if(input.name==="author"&&input.value.startsWith("Author: ")){input.value=input.value.substring("Author: ".length);}});inputs[0].focus();editButton.style.display="none";var saveButton=listItem.querySelector(".save-btn");saveButton.style.display="inline-block";inputs.forEach(function(input){input.addEventListener("keypress",function(event){if(event.key==="Enter"){event.preventDefault();saveButton.click();}});});}
 function updateFileList(){const fileList=fileInput.files;totalPages=fileList.length;document.getElementById("total-pages").textContent=totalPages;createDocumentForms(fileList);displayCurrentForm();updatePaginationControls();}
-function createDocumentForms(fileList){documentForms=[];for(let i=0;i<fileList.length;i++){const file=fileList[i];const formHtml=`<div class="form-group"><label>Document Title(optional):</label><input type="text"name="title"placeholder="Enter document title"value="${
+function createDocumentForms(fileList){documentForms=[];for(let i=0;i<fileList.length;i++){const file=fileList[i];const formHtml=`<div class="form-group"><label>Title&nbsp;(optional):</label><input type="text"name="title"placeholder="Enter document title"value="${
       documentData[i]?.title || ""
-    }"/></div><div class="form-group"><label>Author Name(optional):</label><input type="text"name="author"placeholder="Enter author's name"value="${
+    }"/></div><div class="form-group"><label>Author&nbsp;(optional):</label><input type="text"name="author"placeholder="Enter author's name"value="${
       documentData[i]?.author || ""
-    }"/></div><div class="form-group"><label>Max Tokens per Chunk(default is 512):</label><input type="number"name="chunk_size"min="1"value="${
-      documentData[i]?.chunk_size || "512"
-    }"/></div><div class="form-group"><label><input type="checkbox"name="advanced_preprocessing"${documentData[i]?.advanced_preprocessing?"checked":""}/>Enable Advanced Preprocessing</label></div>`;documentForms.push(formHtml);}}
+    }"/></div><div class="form-group"><label>Tokens per Chunk&nbsp;(default is 1024):</label><input type="number"name="chunk_size"min="1"value="${
+      documentData[i]?.chunk_size || "1024"
+    }"/></div><div class="form-group"><label><input type="checkbox"name="advanced_preprocessing"${documentData[i]?.advanced_preprocessing?"checked":""}/>&nbsp;Advanced PDF Preprocessing?</label></div>`;documentForms.push(formHtml);}}
 function updatePaginationControls(){if(totalPages>1){paginationControls.style.display="flex";submitButton.disabled=false;}else{paginationControls.style.display="none";submitButton.disabled=totalPages===0;}}
 function onSubmit(event){event.preventDefault();const formData=new FormData();const fileList=fileInput.files;for(let i=0;i<fileList.length;i++){const file=fileList[i];const fileType=file.type;const fileExtension=file.name.split(".").pop().toLowerCase();if(fileType!=="text/plain"&&fileType!=="application/pdf"&&!["py","html","css","js","md","yml","json"].includes(fileExtension)){updateUploadMessages("Only .txt, .pdf, .py, .html, .css, .js, .md, .yml, and .json files are allowed.","error",);return;}
 let title=document.querySelector('input[name="title"]').value;if(["py","html","css","js","md","yml","json"].includes(fileExtension)){if(title){title=`${title}(${file.name})`;}else{title=file.name;}}else{title=title||file.name;}


### PR DESCRIPTION
- Update allowed CORS origins for socket connections to include `http://127.0.0.1:8080`
- Remove logging configurations from socket initialization
- Change model identifier in `ask` function from `gpt-4o` to `gpt-4-0125-preview`
- Simplify labels in document form UI from `Document Title (optional)` to `Title (optional)` and `Author Name (optional)` to `Author (optional)`
- Increase default token limit per chunk from `512` to `1024` in document forms
- Change checkbox label for preprocessing in document forms to `Advanced PDF Preprocessing?`